### PR TITLE
Bump to use pytest-asyncio ~=0.25 which deprecate get_event_loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ pre-commit = [
 ]
 tests = [
     'ipykernel==6.12.1',
-    'pytest~=7.0',
-    'pytest-asyncio~=0.12,<0.17',
+    'pytest~=8.0',
+    'pytest-asyncio~=0.25',
     'pytest-cov~=4.1',
     'pytest-notebook>=0.8.0',
     'shortuuid==1.0.8',
@@ -163,6 +163,7 @@ testpaths = [
     'test',
 ]
 filterwarnings = []
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.yapf]
 align_closing_bracket_with_visual_indent = true

--- a/src/plumpy/rmq/process_control.py
+++ b/src/plumpy/rmq/process_control.py
@@ -84,6 +84,10 @@ class RemoteProcessController:
     def __init__(self, coordinator: Coordinator) -> None:
         self._coordinator = coordinator
 
+    @property
+    def coordinator(self) -> Coordinator:
+        return self._coordinator
+
     async def get_status(self, pid: 'PID_TYPE') -> 'ProcessStatus':
         """
         Get the status of a process with the given PID
@@ -249,6 +253,10 @@ class RemoteProcessThreadController:
 
         """
         self._coordinator = coordinator
+
+    @property
+    def coordinator(self) -> Coordinator:
+        return self._coordinator
 
     def get_status(self, pid: 'PID_TYPE') -> kiwipy.Future:
         """Get the status of a process with the given PID.

--- a/tests/rmq/test_communicator.py
+++ b/tests/rmq/test_communicator.py
@@ -2,19 +2,15 @@
 """Tests for the :mod:`plumpy.rmq.communicator` module."""
 
 import asyncio
-import functools
 import shutil
 import tempfile
 import uuid
 import pytest
 import shortuuid
-# import yaml
-import msgpack
 
 from kiwipy.rmq import RmqThreadCommunicator
 
 import plumpy
-from plumpy.coordinator import Coordinator
 from plumpy.rmq import communications, process_control
 
 from . import RmqCoordinator
@@ -56,36 +52,71 @@ def _coordinator():
     coordinator.close()
 
 
-@pytest.fixture
-def async_controller(_coordinator):
-    yield process_control.RemoteProcessController(_coordinator)
+@pytest.fixture(scope='function')
+def make_coordinator():
+    def _coordinator(loop=None):
+        message_exchange = f'{__file__}.{shortuuid.uuid()}'
+        task_exchange = f'{__file__}.{shortuuid.uuid()}'
+        task_queue = f'{__file__}.{shortuuid.uuid()}'
+
+        thread_comm = RmqThreadCommunicator.connect(
+            connection_params={'url': 'amqp://guest:guest@localhost:5672/'},
+            message_exchange=message_exchange,
+            task_exchange=task_exchange,
+            task_queue=task_queue,
+            encoder=process_control.MSGPACK_ENCODER,
+            decoder=process_control.MSGPACK_DECODER,
+        )
+
+        loop = loop or asyncio.get_event_loop()
+        loop.set_debug(True)
+        comm = communications.LoopCommunicator(thread_comm, loop=loop)
+        coordinator = RmqCoordinator(comm)
+
+        return coordinator
+
+    return _coordinator
+
+
+@pytest.fixture(scope='function')
+def make_controller(make_coordinator):
+    def _controller(loop=None):
+        coordinator = make_coordinator(loop)
+        controller = process_control.RemoteProcessController(coordinator)
+
+        return controller
+
+    return _controller
 
 
 class TestLoopCommunicator:
     """Make sure the loop communicator is working as expected"""
 
     @pytest.mark.asyncio
-    async def test_broadcast(self, _coordinator):
+    async def test_broadcast(self, make_coordinator):
+        loop = asyncio.get_running_loop()
+        coordinator = make_coordinator(loop)
         BROADCAST = {'body': 'present', 'sender': 'Martin', 'subject': 'sup', 'correlation_id': 420}  # noqa: N806
         broadcast_future = asyncio.Future()
 
-        loop = asyncio.get_event_loop()
-
         def get_broadcast(_comm, body, sender, subject, correlation_id):
-            assert loop is asyncio.get_event_loop()
+            assert loop is asyncio.get_running_loop()
 
             broadcast_future.set_result(
                 {'body': body, 'sender': sender, 'subject': subject, 'correlation_id': correlation_id}
             )
 
-        _coordinator.add_broadcast_subscriber(get_broadcast)
-        _coordinator.broadcast_send(**BROADCAST)
+        coordinator.add_broadcast_subscriber(get_broadcast)
+        coordinator.broadcast_send(**BROADCAST)
 
         result = await broadcast_future
         assert result == BROADCAST
 
     @pytest.mark.asyncio
-    async def test_broadcast_filter(self, _coordinator: Coordinator):
+    async def test_broadcast_filter(self, make_coordinator):
+        loop = asyncio.get_running_loop()
+        coordinator = make_coordinator(loop)
+
         broadcast_future = asyncio.Future()
 
         def ignore_broadcast(_comm, body, sender, subject, correlation_id):
@@ -94,15 +125,18 @@ class TestLoopCommunicator:
         def get_broadcast(_comm, body, sender, subject, correlation_id):
             broadcast_future.set_result(True)
 
-        _coordinator.add_broadcast_subscriber(ignore_broadcast, subject_filters=['other'])
-        _coordinator.add_broadcast_subscriber(get_broadcast)
-        _coordinator.broadcast_send(**{'body': 'present', 'sender': 'Martin', 'subject': 'sup', 'correlation_id': 420})
+        coordinator.add_broadcast_subscriber(ignore_broadcast, subject_filters=['other'])
+        coordinator.add_broadcast_subscriber(get_broadcast)
+        coordinator.broadcast_send(**{'body': 'present', 'sender': 'Martin', 'subject': 'sup', 'correlation_id': 420})
 
         result = await broadcast_future
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_rpc(self, _coordinator):
+    async def test_rpc(self, make_coordinator):
+        loop = asyncio.get_running_loop()
+        coordinator = make_coordinator(loop)
+
         MSG = 'rpc this'  # noqa: N806
         rpc_future = asyncio.Future()
 
@@ -112,14 +146,17 @@ class TestLoopCommunicator:
             assert loop is asyncio.get_event_loop()
             rpc_future.set_result(msg)
 
-        _coordinator.add_rpc_subscriber(get_rpc, 'rpc')
-        _coordinator.rpc_send('rpc', MSG)
+        coordinator.add_rpc_subscriber(get_rpc, 'rpc')
+        coordinator.rpc_send('rpc', MSG)
 
         result = await rpc_future
         assert result == MSG
 
     @pytest.mark.asyncio
-    async def test_task(self, _coordinator):
+    async def test_task(self, make_coordinator):
+        loop = asyncio.get_running_loop()
+        coordinator = make_coordinator(loop)
+
         TASK = 'task this'  # noqa: N806
         task_future = asyncio.Future()
 
@@ -129,8 +166,8 @@ class TestLoopCommunicator:
             assert loop is asyncio.get_event_loop()
             task_future.set_result(msg)
 
-        _coordinator.add_task_subscriber(get_task)
-        _coordinator.task_send(TASK)
+        coordinator.add_task_subscriber(get_task)
+        coordinator.task_send(TASK)
 
         result = await task_future
         assert result == TASK
@@ -138,48 +175,53 @@ class TestLoopCommunicator:
 
 class TestTaskActions:
     @pytest.mark.asyncio
-    async def test_launch(self, _coordinator, async_controller, persister):
+    async def test_launch(self, make_controller, persister):
         # Let the process run to the end
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
-        result = await async_controller.launch_process(utils.DummyProcess)
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        result = await controller.launch_process(utils.DummyProcess)
         # Check that we got a result
         assert result == utils.DummyProcess.EXPECTED_OUTPUTS
 
     @pytest.mark.asyncio
-    async def test_launch_nowait(self, _coordinator, async_controller, persister):
+    async def test_launch_nowait(self, make_controller, persister):
         """Testing launching but don't wait, just get the pid"""
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
-        pid = await async_controller.launch_process(utils.DummyProcess, nowait=True)
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        pid = await controller.launch_process(utils.DummyProcess, nowait=True)
         assert isinstance(pid, uuid.UUID)
 
     @pytest.mark.asyncio
-    async def test_execute_action(self, _coordinator, async_controller, persister):
+    async def test_execute_action(self, make_controller, persister):
         """Test the process execute action"""
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
-        result = await async_controller.execute_process(utils.DummyProcessWithOutput)
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        result = await controller.execute_process(utils.DummyProcessWithOutput)
         assert utils.DummyProcessWithOutput.EXPECTED_OUTPUTS == result
 
     @pytest.mark.asyncio
-    async def test_execute_action_nowait(self, _coordinator, async_controller, persister):
+    async def test_execute_action_nowait(self, make_controller, persister):
         """Test the process execute action"""
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
-        pid = await async_controller.execute_process(utils.DummyProcessWithOutput, nowait=True)
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        pid = await controller.execute_process(utils.DummyProcessWithOutput, nowait=True)
         assert isinstance(pid, uuid.UUID)
 
     @pytest.mark.asyncio
-    async def test_launch_many(self, _coordinator, async_controller, persister):
+    async def test_launch_many(self, make_controller, persister):
         """Test launching multiple processes"""
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
         num_to_launch = 10
 
         launch_futures = []
         for _ in range(num_to_launch):
-            launch = async_controller.launch_process(utils.DummyProcess, nowait=True)
+            launch = controller.launch_process(utils.DummyProcess, nowait=True)
             launch_futures.append(launch)
 
         results = await asyncio.gather(*launch_futures)
@@ -187,15 +229,16 @@ class TestTaskActions:
             assert isinstance(result, uuid.UUID)
 
     @pytest.mark.asyncio
-    async def test_continue(self, _coordinator, async_controller, persister):
+    async def test_continue(self, make_controller, persister):
         """Test continuing a saved process"""
-        loop = asyncio.get_event_loop()
-        _coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
+        loop = asyncio.get_running_loop()
+        controller = make_controller(loop)
+        controller.coordinator.add_task_subscriber(plumpy.ProcessLauncher(loop, persister=persister))
         process = utils.DummyProcessWithOutput()
         persister.save_checkpoint(process)
         pid = process.pid
         del process
 
         # Let the process run to the end
-        result = await async_controller.continue_process(pid)
+        result = await controller.continue_process(pid)
         assert result, utils.DummyProcessWithOutput.EXPECTED_OUTPUTS

--- a/uv.lock
+++ b/uv.lock
@@ -1551,8 +1551,8 @@ requires-dist = [
     { name = "myst-nb", marker = "extra == 'docs'", specifier = "~=0.11.0" },
     { name = "nest-asyncio", specifier = "~=1.5,>=1.5.1" },
     { name = "pre-commit", marker = "extra == 'pre-commit'", specifier = "~=2.2" },
-    { name = "pytest", marker = "extra == 'tests'", specifier = "~=7.0" },
-    { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.12,<0.17" },
+    { name = "pytest", marker = "extra == 'tests'", specifier = "~=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.25" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = "~=4.1" },
     { name = "pytest-notebook", marker = "extra == 'tests'", specifier = ">=0.8.0" },
     { name = "pyyaml", specifier = "~=6.0" },
@@ -1765,7 +1765,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1775,21 +1775,21 @@ dependencies = [
     { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287 },
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.16.0"
+version = "0.25.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/53/8844d99d5343eecbb6d740d708581fbf63cefd560c07c7164b12691e54eb/pytest-asyncio-0.16.0.tar.gz", hash = "sha256:7496c5977ce88c34379df64a66459fe395cd05543f0a2f837016e7144391fcfb", size = 12095 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/d0/d9bd672577857bb59004d7a0902abb5f27770c1d234860a08898eb058bd2/pytest_asyncio-0.16.0-py3-none-any.whl", hash = "sha256:5f2a21273c47b331ae6aa5b36087047b4899e40f03f18397c0e65fa5cca54e9b", size = 12119 },
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
The event loop set up of coordinator and controller is from using the same event loop of a single async pytest. 
This maximum the decouple of tests in `tests/rmq/test_communication.py`.
The fixture and the event loop scope of async test are both set to "function".