### PR TITLE
Using customized get_event_loop from PlumpyEventLoopPolicy

### DIFF
--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -340,7 +340,7 @@ class Process(StateMachine, metaclass=ProcessStateMachineMeta):
         # Don't allow the spec to be changed anymore
         self.spec().seal()
 
-        self._loop = loop if loop is not None else asyncio.get_event_loop()
+        self._loop = loop or asyncio.get_event_loop()
 
         self._setup_event_hooks()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from plumpy.events import set_event_loop_policy, reset_event_loop_policy
 
-@pytest.fixture(scope='session')
-def set_event_loop_policy():
-    from plumpy import set_event_loop_policy
 
+@pytest.fixture(scope='function')
+def custom_event_loop_policy():
+    """This is the fixture for changing the event loop of synchronous tests.
+    If using `@pytest.mark.asyncio`, the event loop can be set by `event_loop_policy`
+    fixture of pytest-asyncio.
+    """
     set_event_loop_policy()
+    yield
+    reset_event_loop_policy()

--- a/tests/persistence/test_inmemory.py
+++ b/tests/persistence/test_inmemory.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-
+import pytest
 import plumpy
 
 from ..utils import ProcessWithCheckpoint
 
 
 class TestInMemoryPersister:
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_save_load_roundtrip(self):
         """
         Test the plumpy.PicklePersister by taking a dummpy process, saving a checkpoint
@@ -16,6 +17,7 @@ class TestInMemoryPersister:
         persister = plumpy.InMemoryPersister()
         persister.save_checkpoint(process)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_checkpoints_without_tags(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -34,6 +36,7 @@ class TestInMemoryPersister:
 
         assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_checkpoints_with_tags(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -54,6 +57,7 @@ class TestInMemoryPersister:
 
         assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_process_checkpoints(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -74,6 +78,7 @@ class TestInMemoryPersister:
 
         assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_delete_process_checkpoints(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -100,6 +105,7 @@ class TestInMemoryPersister:
 
         assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_delete_checkpoint(self):
         """ """
         process_a = ProcessWithCheckpoint()

--- a/tests/persistence/test_pickle.py
+++ b/tests/persistence/test_pickle.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import tempfile
 
+import pytest
+
 if getattr(tempfile, 'TemporaryDirectory', None) is None:
     from backports import tempfile
 
@@ -10,6 +12,7 @@ from ..utils import ProcessWithCheckpoint
 
 
 class TestPicklePersister:
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_save_load_roundtrip(self):
         """
         Test the plumpy.PicklePersister by taking a dummpy process, saving a checkpoint
@@ -21,6 +24,7 @@ class TestPicklePersister:
             persister = plumpy.PicklePersister(directory)
             persister.save_checkpoint(process)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_checkpoints_without_tags(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -40,6 +44,7 @@ class TestPicklePersister:
 
             assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_checkpoints_with_tags(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -61,6 +66,7 @@ class TestPicklePersister:
 
             assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_get_process_checkpoints(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -82,6 +88,7 @@ class TestPicklePersister:
 
             assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_delete_process_checkpoints(self):
         """ """
         process_a = ProcessWithCheckpoint()
@@ -109,6 +116,7 @@ class TestPicklePersister:
 
             assert set(retrieved_checkpoints) == set(checkpoints)
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_delete_checkpoint(self):
         """ """
         process_a = ProcessWithCheckpoint()

--- a/tests/rmq/test_communications.py
+++ b/tests/rmq/test_communications.py
@@ -43,6 +43,7 @@ def subscriber():
     return Subscriber()
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_add_rpc_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.add_rpc_subscriber` method."""
     assert _coordinator.add_rpc_subscriber(subscriber) is not None
@@ -51,12 +52,14 @@ def test_add_rpc_subscriber(_coordinator, subscriber):
     assert _coordinator.add_rpc_subscriber(subscriber, identifier) == identifier
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_remove_rpc_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.remove_rpc_subscriber` method."""
     identifier = _coordinator.add_rpc_subscriber(subscriber)
     _coordinator.remove_rpc_subscriber(identifier)
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_add_broadcast_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.add_broadcast_subscriber` method."""
     assert _coordinator.add_broadcast_subscriber(subscriber) is not None
@@ -65,17 +68,20 @@ def test_add_broadcast_subscriber(_coordinator, subscriber):
     assert _coordinator.add_broadcast_subscriber(subscriber, identifier=identifier) == identifier
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_remove_broadcast_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.remove_broadcast_subscriber` method."""
     identifier = _coordinator.add_broadcast_subscriber(subscriber)
     _coordinator.remove_broadcast_subscriber(identifier)
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_add_task_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.add_task_subscriber` method."""
     assert _coordinator.add_task_subscriber(subscriber) is not None
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_remove_task_subscriber(_coordinator, subscriber):
     """Test the `LoopCommunicator.remove_task_subscriber` method."""
     identifier = _coordinator.add_task_subscriber(subscriber)

--- a/tests/rmq/test_communicator.py
+++ b/tests/rmq/test_communicator.py
@@ -27,31 +27,6 @@ def persister():
     shutil.rmtree(_tmppath)
 
 
-@pytest.fixture
-def _coordinator():
-    message_exchange = f'{__file__}.{shortuuid.uuid()}'
-    task_exchange = f'{__file__}.{shortuuid.uuid()}'
-    task_queue = f'{__file__}.{shortuuid.uuid()}'
-
-    thread_comm = RmqThreadCommunicator.connect(
-        connection_params={'url': 'amqp://guest:guest@localhost:5672/'},
-        message_exchange=message_exchange,
-        task_exchange=task_exchange,
-        task_queue=task_queue,
-        encoder=process_control.MSGPACK_ENCODER,
-        decoder=process_control.MSGPACK_DECODER,
-    )
-
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
-    comm = communications.LoopCommunicator(thread_comm, loop=loop)
-    coordinator = RmqCoordinator(comm)
-
-    yield coordinator
-
-    coordinator.close()
-
-
 @pytest.fixture(scope='function')
 def make_coordinator():
     def _coordinator(loop=None):

--- a/tests/rmq/test_process_control.py
+++ b/tests/rmq/test_process_control.py
@@ -7,10 +7,16 @@ import shortuuid
 from kiwipy import rmq
 
 import plumpy
+from plumpy.events import PlumpyEventLoopPolicy
 from plumpy.rmq import process_control
 
 from . import RmqCoordinator
 from .. import utils
+
+
+@pytest.fixture(scope='module')
+def event_loop_policy(request):
+    return PlumpyEventLoopPolicy()
 
 
 @pytest.fixture


### PR DESCRIPTION
fixes #25 

This can remove the get_event_loop deprecation warning.