### PR TITLE
Using custom event loop for nested process tests

### DIFF
--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -41,6 +41,7 @@ class ForgetToCallParent(plumpy.Process):
             super().on_kill(msg)
 
 
+@pytest.mark.usefixtures('custom_event_loop_policy')
 def test_process_is_savable():
     proc = utils.DummyProcess()
     assert isinstance(proc, Savable)
@@ -584,6 +585,7 @@ class TestProcess:
         proc = StackTest()
         proc.execute()
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_process_stack_multiple(self):
         """
         Run multiple and nested processes to make sure the process stack is always correct
@@ -619,6 +621,7 @@ class TestProcess:
 
         assert len(expect_true) == n_run * 3
 
+    @pytest.mark.usefixtures('custom_event_loop_policy')
     def test_process_nested(self):
         """
         Run multiple and nested processes to make sure the process stack is always correct


### PR DESCRIPTION
fixes #20 

As expected, should using the plumpy event loop. But it shows a problem that the custom event loop from tests in other places not set back to the regular event loop.